### PR TITLE
Potential fix for code scanning alert no. 1: Information exposure through an exception

### DIFF
--- a/app.py
+++ b/app.py
@@ -74,7 +74,9 @@ def generate_chatgpt_fact():
 
         return jsonify({"success": True, "message": "Fact generated successfully!", "fact": fact})
     except Exception as e:
-        return jsonify({"success": False, "message": f"Error: {str(e)}"}), 500
+        import logging
+        logging.error("An error occurred: %s", str(e), exc_info=True)
+        return jsonify({"success": False, "message": "An internal error has occurred."}), 500
 
 # Utility: Ensure default locations and facts
 def ensure_defaults():


### PR DESCRIPTION
Potential fix for [https://github.com/DaryAkerman/weather-app/security/code-scanning/1](https://github.com/DaryAkerman/weather-app/security/code-scanning/1)

To fix the issue, the code should avoid exposing the exception details (`str(e)`) to the user. Instead, a generic error message should be returned to the client, while the detailed exception information (including stack trace) should be logged on the server for debugging purposes. This ensures that developers can still access the necessary information to diagnose issues without exposing sensitive details to external users.

The fix involves:
1. Replacing the user-facing error message with a generic message like `"An internal error has occurred."`.
2. Logging the exception details (including stack trace) on the server using Python's `logging` module.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
